### PR TITLE
General Fixes and new Github Regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,160 @@
-logs/*
-sources*
-pdfs/*
-*.xls
-*.xlsx
-_downloader.py
-results.csv
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/src/latex/latex_matcher.py
+++ b/src/latex/latex_matcher.py
@@ -49,9 +49,15 @@ class LatexMatcher:
             results.setdefault(arxiv_id, {})
             with open(filepath) as fp:
                 text = fp.read()
-
-                repos_ids = repos_finder.find(arxiv_id, text, contextualized=True)
-                results[arxiv_id] = pub_finder.find(arxiv_id, repos_ids)
+                if not (repos_ids := repos_finder.find(arxiv_id, text, contextualized=False)):
+                    logging.error(f"latex_matcher: No repo ids found in {arxiv_id}")
+                    continue
+                if not (found_publis := pub_finder.find(arxiv_id, repos_ids)):
+                    logging.error(f"latex_matcher: No publications ids found in {arxiv_id}")
+                    continue
+                results[arxiv_id] = found_publis
+                # repos_ids = repos_finder.find(arxiv_id, text, contextualized=True)
+                # results[arxiv_id] = pub_finder.find(arxiv_id, repos_ids)
 
         self._github.close()
 

--- a/src/latex/latex_matcher.py
+++ b/src/latex/latex_matcher.py
@@ -12,7 +12,7 @@ from ..pub_finder import PubFinder
 logger = logging.getLogger("Latex Matcher")
 
 ARXIV_ID_REGEX = r"/(\d+\.\d+)(:v\d+)?/"
-
+#ARXIV_ID_REGEX = r"/(\d+\.\d+)(:v\d+)?/"
 
 class LatexMatcher:
     SOURCES_FOLDER = "sources"
@@ -42,8 +42,10 @@ class LatexMatcher:
         for filepath in filepaths:
             i += 1
             logger.info(f"Working on `{filepath}` - {i}/{total}")
-
-            arxiv_id = re.search(ARXIV_ID_REGEX, filepath)[1]
+            match = re.search(ARXIV_ID_REGEX, filepath)
+            if not match:
+                continue
+            arxiv_id = match[1]
             results.setdefault(arxiv_id, {})
             with open(filepath) as fp:
                 text = fp.read()

--- a/src/pub_finder.py
+++ b/src/pub_finder.py
@@ -33,12 +33,22 @@ class PubFinder:
 
     def _zenodo(self, publication_id, _id):
         recid_or_doi = _id
-        record_text, correct_url = self._zenodo_apis.get_record(recid_or_doi)
-        return record_text, correct_url
+        if zenodo_record := self._zenodo_apis.get_record(recid_or_doi):
+            record_text, correct_url = zenodo_record
+            return record_text, correct_url
+        logging.error("_zenodo: Zenodo API has returned a Non-usable value")
+        return "", ""
 
     def find(self, publication_id, repo_ids):
         """Find publication URL in repos metadata or files."""
         results = {}
+        if not repo_ids:
+            logging.error(f"pub_finder_find Error: no ID's given for repos: '{repo_ids}'.")
+            return results
+        if not publication_id:
+            logging.error("pub_finder_find Error: The publication ID is empty or None.")
+            return results
+
         arxiv_url = ARXIV_URL_REGEX.format(arxiv_id=publication_id)
         for repo, ids in repo_ids.items():
             if repo == Repos.GITHUB.value:

--- a/src/repos_finder.py
+++ b/src/repos_finder.py
@@ -23,7 +23,7 @@ URLS_REGEX = [
     (
         Repos.GITHUB.value,
         "https?://(?:www\.)?github\.com/([a-zA-Z0-9_.-]+)/([a-zA-Z0-9_.-]+)",
-    ),  # FIXME: review allowed org/repo names in GitHub
+    ),
     (Repos.ZENODO_RECORD.value, "https?://zenodo\.org/records?/(\d+)"),
     (Repos.ZENODO_DOI.value, "(https?://doi\.org/10\.5281/zenodo\.\d+)"),
     # ADD MORE
@@ -33,6 +33,7 @@ MAX_DISTANCE_BEFORE_REGEX = r"(?:\s+\S+){{0,{N_WORDS}}}"
 URL_MATCH_BEFORE_REGEX = r"{keywords}{max_distance}(?:\s+|){url}"
 MAX_DISTANCE_AFTER_REGEX = r"(?:\S+\s+){{0,{N_WORDS}}}"
 URL_MATCH_AFTER_REGEX = r"{url}(?:\s+|){max_distance}{keywords}"
+
 
 class ReposFinder:
     """Find repos URLs in text."""
@@ -46,6 +47,35 @@ class ReposFinder:
         else:
             return _tuple
 
+    def _clean_repo_name(self, repo_name: str) -> str or None:
+        # Strip the trailing period if it exists
+        modified = False
+        if repo_name.endswith('.'):
+            repo_name = repo_name[:-1]
+            modified = True
+        # Strip '.git' if it exists
+        if repo_name.endswith('.git'):
+            repo_name = repo_name[:-4]
+            modified = True
+        return repo_name if modified else None
+
+    def _clean_urls(self, urls: list) -> list:
+        clean_urls = set()
+        for _tuple in urls:
+            non_empty = self._clean_empty_tuples(_tuple)
+            # GitHub, as of 2023, allows URLs to end with a "."
+            clean_urls.add(non_empty)  # To avoid wrongful removal of "." adding unmodified url initially.
+            if isinstance(non_empty, tuple):
+                if cleaned := self._clean_repo_name(non_empty[1]):
+                    clean_urls.add((non_empty[0], cleaned))
+            elif isinstance(non_empty, str):
+                if cleaned := self._clean_repo_name(non_empty):
+                    clean_urls.add(cleaned)
+            else:
+                logging.warning(f"_clean_urls: The following url has not been considered: {non_empty}, {type(non_empty)}")
+                continue
+        return list(clean_urls)
+
     def _find_contextualized(self, publication_id, text):
         results = dict()
         for repo, url_regex in URLS_REGEX:
@@ -56,9 +86,10 @@ class ReposFinder:
                     keywords=KEYWORDS_REGEX.format(KEYWORDS="|".join(KEYWORDS)),
                     url=url_regex,
                 )
+                text = text.replace("\-", "-").replace("\_", "_")  # Avoids url non recognition due to latex notation
                 urls = re.findall(regex, text, re.M | re.I)
                 if urls:
-                    no_empty_urls = [self._clean_empty_tuples(_tuple) for _tuple in urls]  # keep only non-empty
+                    no_empty_urls = self._clean_urls(urls)   # keep only non-empty and clean up wrongly extracted urls
                     _urls = [str(t) for t in no_empty_urls]  # convert tuples to string
                     logger.debug(
                         f"{publication_id} | {repo}: found URLs `{', '.join(_urls)}`"
@@ -71,13 +102,15 @@ class ReposFinder:
     def _find_all(self, publication_id, text):
         results = dict()
         for repo, url_regex in URLS_REGEX:
+            text = text.replace("\-", "-").replace("\_", "_") # Avoids url non recognition due to latex notation
             urls = re.findall(url_regex, text, re.M | re.I)
             if urls:
-                _urls = [str(t) for t in urls]  # convert tuples to string
+                clean_urls = self._clean_urls(urls)   # keep only non-empty and clean up wrongly extracted urls
+                _urls = [str(t) for t in clean_urls]  # convert tuples to string
                 logger.debug(
                     f"{publication_id} | {repo}: found URLs `{', '.join(_urls)}`"
                 )
-                results[repo] = urls
+                results[repo] = clean_urls
             else:
                 logger.debug(f"{publication_id} | {repo}: no URLs found")
                 results[repo] = []
@@ -89,6 +122,13 @@ class ReposFinder:
         When contextualized is True, apply heuristics to find only URLs that refer
         to code/dataset of the publication. When False, find all URLs.
         """
+        if not publication_id:
+            logging.error(f"repos_finder.find(): Invalid publication ID given: {publication_id}")
+            return {}
+        if not text:
+            logging.error(f"repos_finder.find(): Invalid text given: {text}")
+            return {}
+
         if contextualized:
             return self._find_contextualized(publication_id, text)
         else:

--- a/src/repos_finder.py
+++ b/src/repos_finder.py
@@ -22,7 +22,7 @@ KEYWORDS = [
 URLS_REGEX = [
     (
         Repos.GITHUB.value,
-        "https?://(?:www\.)?github\.com/([a-zA-Z0-9]+)/([a-zA-Z0-9]+)",
+        "https?://(?:www\.)?github\.com/([a-zA-Z0-9_.-]+)/([a-zA-Z0-9_.-]+)",
     ),  # FIXME: review allowed org/repo names in GitHub
     (Repos.ZENODO_RECORD.value, "https?://zenodo\.org/records?/(\d+)"),
     (Repos.ZENODO_DOI.value, "(https?://doi\.org/10\.5281/zenodo\.\d+)"),


### PR DESCRIPTION
### Github Url extraction Change

**-New regex.** 
Github allows for the following characters: "-" "_" "." within the org name and repo name with no specific order. Changed regex to allow these repos. 

**- Functions to aid new regex:**
Due to this new regex there has been a need to create a  new function to clean those urls extracted with an appended ".". This often occurs when a URL is positioned at the end of a sentence, such as in "You can find our code here: https://github.com/example/repo.". To avoid breaking urls due to  generalisation we made the function redundantly return the url with and without the appended "." 

**- Cleans up the text before hand replacing '\-' and '\_' found in latex notation for '-' and '\'**

### Merge.tex changes

Will now not create an empty merge.tex file if there is no .tex files, makes counting valid merge.tex files easier


### Other

- Error logging
- General returns and checks to avoid Nonetype Exceptions






